### PR TITLE
Write the correct value type for typedefs

### DIFF
--- a/src/BaseCompiler.ts
+++ b/src/BaseCompiler.ts
@@ -333,7 +333,8 @@ export default class BaseCompiler {
     Object.keys(typedefs).forEach((k: keyof TypeDefs) => {
       const typedef = typedefs[k];
       this.wIntend();
-      this.write('type', SPACE, k, SPACE, '=', SPACE, this.getTypeName(typedef.type));
+      this.write('type', SPACE, k, SPACE, '=', SPACE);
+      this.wValueType(this.getTypeName(typedef.type));
       this.write(';\n');
     });
   }

--- a/test/mock/idl/typedef.thrift
+++ b/test/mock/idl/typedef.thrift
@@ -1,0 +1,5 @@
+struct T {
+  1: i64 id
+}
+
+typedef list<T> TList


### PR DESCRIPTION
We should print the correct value type for typedefs by using `wValueType` function of `BaseCompiler`.

> Note: Converting the results of `getTypeName` function to String will be [object Object] which is not a valid typescript expression.

E.g.:
```thirft
struct T {
  1: i64 id
}

typedef list<T> TList
```